### PR TITLE
vicon_sdk uses C++11 components

### DIFF
--- a/mocap_vicon/src/vicon_sdk/CMakeLists.txt
+++ b/mocap_vicon/src/vicon_sdk/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 
+add_compile_options(-std=c++11)
+
 find_package(Boost REQUIRED COMPONENTS thread)
 
 add_library(ViconDataStreamSDK_CPP

--- a/mocap_vicon/src/vicon_sdk/CMakeLists.txt
+++ b/mocap_vicon/src/vicon_sdk/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1.0)
 
-add_compile_options(-std=c++11)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Boost REQUIRED COMPONENTS thread)
 


### PR DESCRIPTION
I added C++11 flags to fix the vicon_sdk compilation error.