### PR TITLE
Mnaveau/fix install

### DIFF
--- a/mocap_base/CMakeLists.txt
+++ b/mocap_base/CMakeLists.txt
@@ -51,3 +51,9 @@ add_dependencies(mocap_base_driver
   ${catkin_EXPORTED_TARGETS}
 )
 
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS mocap_base_driver mocap_kalman_filter
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/mocap_qualisys/CMakeLists.txt
+++ b/mocap_qualisys/CMakeLists.txt
@@ -17,8 +17,8 @@ find_package(catkin REQUIRED COMPONENTS
 
 
 catkin_package(
-  #INCLUDE_DIRS include
-  #LIBRARIES ${PROJECT_NAME}
+  INCLUDE_DIRS include
+  LIBRARIES mocap_qualisys_driver
   CATKIN_DEPENDS
     geometry_msgs tf mocap_base
   DEPENDS
@@ -64,5 +64,9 @@ else()
   message(ERROR " MacOS is unsupported! mocap_qualisys will not be built!")
 endif()
 
-
-
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS mocap_qualisys_driver mocap_qualisys_node
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/mocap_vicon/CMakeLists.txt
+++ b/mocap_vicon/CMakeLists.txt
@@ -50,3 +50,10 @@ target_link_libraries(mocap_vicon_node
   mocap_vicon_driver
   ${catkin_LIBRARIES}
 )
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS mocap_vicon_driver mocap_vicon_node
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)


### PR DESCRIPTION
## Purpose

This PR fixes the installation of this software upon classic cmake build for:
- mocap_base
```
cd motion_capture_system/mocap_base
mkdir _build
cd _build
cmake ..
make
make install
```
- mocap_qualisys
```
cd motion_capture_system/mocap_qualisys
mkdir _build
cd _build
cmake ..
make
make install
```
- mocap_vicon
```
cd motion_capture_system/mocap_vicon
mkdir _build
cd _build
cmake ..
make
make install
```
This also allow one to use `colcon` instead of `catkin` as `colcon` actually installs the packages hence creating a cleaner install space.

## How did I tested?

I built the packages with colcon on my laptop and I ran the mocap_qualysis node successfully with our qualisys system.