### PR TITLE
Fixing installation for ROS2 Humble 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@ For the QUALISYS driver, we use the interface from [Qualisys2Ros](https://github
 For the rest of the software, the license is Apache 2.0 wherever not specified.
 
 ## Compiling
-This is a catkin package. Make sure the package is on `ROS_PACKAGE_PATH` after cloning the package to your workspace. Drivers for different motion capture system can be independently compiled.
-
+To compile, simply use `rosdep` and `colcon build` as follows:
+```bash
+rosdep install --from-paths src -y -i
+colcon build --packages-select mocap_base mocap_vicon  
 ```
-cd your_work_space
-catkin_make --pkg mocap_{sys} --cmake-args -DCMAKE_BUILD_TYPE=Release
-```
 
-This will compile the drivers for `{sys}`
 
 ## Example Usage
 

--- a/mocap_base/package.xml
+++ b/mocap_base/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclcpp</exec_depend>
-  <exec_depend>eigen_conversions</exec_depend>
+  <!-- <exec_depend>eigen_conversions</exec_depend> -->
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/mocap_vicon/package.xml
+++ b/mocap_vicon/package.xml
@@ -18,9 +18,9 @@
 
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>tf</exec_depend>
-  <exec_depend>tf_conversions</exec_depend>
+  <!-- <exec_depend>roscpp</exec_depend> -->
+  <!-- <exec_depend>tf</exec_depend> -->
+  <!-- <exec_depend>tf_conversions</exec_depend> -->
   <exec_depend>mocap_base</exec_depend>
 
   <export>


### PR DESCRIPTION
**Main Fixes:**
- Removed some dependencies (commented out) in `mocap_base` and `mocap_vicon`
- Updated README for correct ROS2 compilation instructions

**mocap_base fixes:**
In `package.xml`:
- `eigen_conversions` was commented out. 

**mocap_vicon fixes:**
In `package.xml`:
- `tf` was commented out. 
- `tf_conversions` was commented out.
- `roscpp` was commented out.

